### PR TITLE
Sp150e compat

### DIFF
--- a/examples/cppl.py
+++ b/examples/cppl.py
@@ -1,0 +1,45 @@
+from pyeclab.device import BiologicDevice
+from pyeclab.techniques import EXIT_COND, OCV_params, OCV_tech, CPLIM
+from pyeclab.channel import Channel, ChannelOptions
+from pyeclab.api.kbio_types import I_RANGE, E_RANGE, BANDWIDTH
+
+IP = "172.28.20.81"
+binary_path = "C:/EC-Lab Development Package/lib/"
+
+device = BiologicDevice(IP, binary_path)
+
+ocv_params = OCV_params(20, 1, 0, 4)
+ocv_technique = OCV_tech(device, device.is_VMP3, ocv_params)
+
+
+cppl = CPLIM(
+    device=device,
+    current=0.01,
+    duration=1 * 1 * 5,
+    vs_init=False,
+    nb_steps=0,
+    record_dt=0.5,
+    record_dE=0.01,
+    repeat=0,
+    i_range=I_RANGE.I_RANGE_1mA,
+    e_range=E_RANGE.E_RANGE_2_5V,
+    exit_cond=EXIT_COND.NEXT_STEP,
+    limit_variable=0b011101,
+    limit_values=10,
+    bandwidth=BANDWIDTH.BW_5,
+)
+
+cppl_technique = cppl.make_technique()
+
+sequence_test = [cppl_technique]
+
+test_options = ChannelOptions("20250122_1112_cppl-test")
+
+channel1 = Channel(
+    device,
+    1,
+    "C:/Users/jconen/Desktop/biologic_data",
+    test_options,
+)
+channel1.load_sequence(sequence_test, ask_ok=True)
+channel1.start()

--- a/examples/cppl.py
+++ b/examples/cppl.py
@@ -1,5 +1,5 @@
 from pyeclab.device import BiologicDevice
-from pyeclab.techniques import EXIT_COND, OCV_params, OCV_tech, CPLIM
+from pyeclab.techniques import EXIT_COND, OCV_params, OCV_tech, CpLim
 from pyeclab.channel import Channel, ChannelOptions
 from pyeclab.api.kbio_types import I_RANGE, E_RANGE, BANDWIDTH
 
@@ -12,7 +12,7 @@ ocv_params = OCV_params(20, 1, 0, 4)
 ocv_technique = OCV_tech(device, device.is_VMP3, ocv_params)
 
 
-cppl = CPLIM(
+cppl = CpLim(
     device=device,
     current=0.01,
     duration=1 * 1 * 5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "matplotlib",
     "pandas",
     "numpy",
+    "attrs",
 ]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/pyeclab/__init__.py
+++ b/src/pyeclab/__init__.py
@@ -1,4 +1,4 @@
 from pyeclab.device import BiologicDevice
 from pyeclab.channel import Channel, ChannelOptions
-from pyeclab.techniques import CPLIM, CA_tech, CA_params, EXIT_COND, OCV_params, OCV_tech
+from pyeclab.techniques import CpLim, CA_tech, CA_params, EXIT_COND, OCV_params, OCV_tech
 from pyeclab.api.kbio_types import I_RANGE, E_RANGE, BANDWIDTH

--- a/src/pyeclab/__init__.py
+++ b/src/pyeclab/__init__.py
@@ -1,4 +1,4 @@
 from pyeclab.device import BiologicDevice
-from pyeclab.channel import Channel
-from pyeclab.techniques import CPLIM, CA_tech, CA_params, EXIT_COND
+from pyeclab.channel import Channel, ChannelOptions
+from pyeclab.techniques import CPLIM, CA_tech, CA_params, EXIT_COND, OCV_params, OCV_tech
 from pyeclab.api.kbio_types import I_RANGE, E_RANGE, BANDWIDTH

--- a/src/pyeclab/__init__.py
+++ b/src/pyeclab/__init__.py
@@ -1,0 +1,4 @@
+from pyeclab.device import BiologicDevice
+from pyeclab.channel import Channel
+from pyeclab.techniques import CPLIM, CA_tech, CA_params, EXIT_COND
+from pyeclab.api.kbio_types import I_RANGE, E_RANGE, BANDWIDTH

--- a/src/pyeclab/api/kbio_api.py
+++ b/src/pyeclab/api/kbio_api.py
@@ -239,7 +239,7 @@ class KBIO_api:
         size = rows * cols
         db = array("L", pb[:size])
 
-        logger.debug("Getting Data in kbio:\n {di}")
+        logger.debug(f"Getting Data in kbio:\n {di}")
 
         # return CurrentValues, DataInfo, Data Records
         return cv, di, db

--- a/src/pyeclab/api/kbio_api.py
+++ b/src/pyeclab/api/kbio_api.py
@@ -21,10 +21,13 @@ This behaviour can be overriden in the BL_xxx functions with an abort flag set t
 """
 
 from array import array
+import logging
 
 import pyeclab.api.kbio_types as KBIO
 from pyeclab.api.c_utils import *
 from pyeclab.api.utils import exception_brief, pp_plural, warn_diff
+
+logger = logging.getLogger("pyeclab")
 
 # ==============================================================================#
 
@@ -235,6 +238,8 @@ class KBIO_api:
         cols = di.NbCols
         size = rows * cols
         db = array("L", pb[:size])
+
+        logger.debug("Getting Data in kbio:\n {di}")
 
         # return CurrentValues, DataInfo, Data Records
         return cv, di, db

--- a/src/pyeclab/channel.py
+++ b/src/pyeclab/channel.py
@@ -249,7 +249,7 @@ class Channel:
         self.current_values, self.data_info, self.data_buffer = self.bio_device.GetData(
             self.bio_device.device_id, self.num
         )
-        logger.debug("Got Data:\n{self.data_info}")
+        logger.debug(f"Got Data:\n{self.data_info}")
 
     def _get_converted_buffer(self):
         """

--- a/src/pyeclab/channel.py
+++ b/src/pyeclab/channel.py
@@ -4,6 +4,7 @@ from collections import deque, namedtuple
 from datetime import datetime
 from pathlib import Path
 from threading import Thread
+import logging
 
 import numpy as np
 
@@ -11,6 +12,8 @@ from pyeclab.api.tech_types import TECH_ID
 from pyeclab.device import BiologicDevice
 from pyeclab.liveplot import LivePlot
 from pyeclab.techniques import reset_duration, set_duration_to_1s
+
+logger = logging.getLogger("pyeclab")
 
 try:
     from np_rw_buffer import RingBuffer
@@ -201,6 +204,7 @@ class Channel:
         Retrives latest measurement data from the BioLogic device, converts and
         saves. The sequence progression is also monitored.
         """
+        logger.debug("Starting Data Loop (_retrieve_data_loop)")
         while True:
             self.latest_data = self._get_measurement_values()
             # Write latest data to open saving file
@@ -245,6 +249,7 @@ class Channel:
         self.current_values, self.data_info, self.data_buffer = self.bio_device.GetData(
             self.bio_device.device_id, self.num
         )
+        logger.debug("Got Data:\n{self.data_info}")
 
     def _get_converted_buffer(self):
         """

--- a/src/pyeclab/channel.py
+++ b/src/pyeclab/channel.py
@@ -86,7 +86,7 @@ class Channel:
         is_recording_analog_In2: bool = False,
         is_charge_recorded: bool = False,
         is_printing_values: bool = False,
-        callbacks=[],
+        callbacks: list | None = None,
     ):
         self.bio_device = bio_device
         self.num = channel_num
@@ -96,7 +96,7 @@ class Channel:
         # Class behaviour
         self.print_values = is_printing_values
         self.is_live_plotting = is_live_plotting
-        self.callbacks = callbacks
+        self.callbacks = [] if callbacks is None else callbacks
         self.current_tech_index = 0
         self.current_loop = 0
         # Hardware setting
@@ -339,7 +339,8 @@ class Channel:
         """
         if not _has_buffer:
             raise ImportError(
-                "The optional dependency 'np-rw-buffer' is required to do this, install it with 'pip install pyeclab[buffer]'"
+                """The optional dependency 'np-rw-buffer' is required to do this, 
+                install it with 'pip install pyeclab[buffer]'"""
             )
         latest_points = RingBuffer(points_avarage)
         self.conditions_average.append((quantity, operator, threshold, points_avarage, latest_points))

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -133,7 +133,7 @@ def OCV_tech(api, is_VMP3, parameters):
 
 
 # ------CPLIM------- #
-@dataclass
+@dataclass(kw_only=True)
 class CPLIM_params:
     current: float
     duration: float
@@ -145,10 +145,10 @@ class CPLIM_params:
     i_range: int
     e_range: int
     exit_cond: int
-    xctr: int | None = None
     limit_variable: int
     limit_values: float
     bandwidth: int
+    xctr: int | None = None
     # analog_filter  : int
 
 

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -38,6 +38,8 @@ For each technique are provided:
 from collections import namedtuple
 from dataclasses import dataclass
 
+from attrs import define
+
 import pyeclab.api.kbio_types as KBIO
 from pyeclab.device import BiologicDevice
 import pyeclab.tech_names as tn
@@ -133,7 +135,7 @@ def OCV_tech(api, is_VMP3, parameters):
 
 
 # ------CPLIM------- #
-@dataclass(kw_only=True)
+@define
 class CPLIM_params:
     current: float
     duration: float

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -146,7 +146,7 @@ class EXIT_COND(Enum):
 
 
 @define(kw_only=True)
-class CPLIM:
+class CpLim:
     device: BiologicDevice
     current: float
     duration: float = field(validator=validators.ge(0))
@@ -170,7 +170,7 @@ class CPLIM:
     xctr: int | None = None
     # analog_filter  : int
 
-    def _make_cplim_parms(self):
+    def make_cplim_parms(self):
         # dictionary of CP parameters (non exhaustive)
         CPLIM_parm_names = {
             "current_step": ECC_parm("Current_step", float),
@@ -230,7 +230,7 @@ class CPLIM:
         tech_file_CPLIM = cplim3_tech_file if self.device.is_VMP3 else cplim4_tech_file
 
         # Define parameters for loading in the device using the templates
-        ecc_parms_CPLIM = self._make_cplim_parms()
+        ecc_parms_CPLIM = self.make_cplim_parms()
 
         CPLIM_tech = namedtuple("CPLIM_tech", "ecc_file ecc_params")
         return CPLIM_tech(tech_file_CPLIM, ecc_parms_CPLIM)

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -43,6 +43,7 @@ from wsgiref.validate import validator
 from attrs import define, field, validators
 
 import pyeclab.api.kbio_types as KBIO
+from pyeclab.api.tech_types import TECH_ID
 from pyeclab.device import BiologicDevice
 import pyeclab.tech_names as tn
 from pyeclab.api.kbio_api import KBIO_api
@@ -65,12 +66,17 @@ def set_duration_to_1s(api, technique, tech_id):
     }
     idx = 0  # Only one current step is used
     p_current_steps = list()
-    if tech_id == 155:
+    if tech_id == TECH_ID.CPLIMIT.value:
         p_current_steps.append(make_ecc_parm(api, parameters["current_step"], technique.user_params.current, idx))
-    elif tech_id == 101:
+
+    elif tech_id == TECH_ID.CA.value:
         p_current_steps.append(make_ecc_parm(api, parameters["voltage_step"], technique.user_params.voltage, idx))
+
+    if tech_id != TECH_ID.OCV.value:
+        p_current_steps.append(make_ecc_parm(api, parameters["vs_init"], technique.user_params.vs_init, idx))
+
     p_current_steps.append(make_ecc_parm(api, parameters["step_duration"], new_duration, idx))
-    p_current_steps.append(make_ecc_parm(api, parameters["vs_init"], technique.user_params.vs_init, idx))
+
     return make_ecc_parms(api, *p_current_steps)
 
 

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -92,12 +92,17 @@ def reset_duration(api, technique, tech_id):
     }
     idx = 0  # Only one current step is used
     p_current_steps = list()
-    if tech_id == 155:
+    if tech_id == TECH_ID.CPLIMIT.value:
         p_current_steps.append(make_ecc_parm(api, parameters["current_step"], technique.user_params.current, idx))
-    elif tech_id == 101:
+
+    elif tech_id == TECH_ID.CA.value:
         p_current_steps.append(make_ecc_parm(api, parameters["voltage_step"], technique.user_params.voltage, idx))
+
+    if tech_id != TECH_ID.OCV.value:
+        p_current_steps.append(make_ecc_parm(api, parameters["vs_init"], technique.user_params.vs_init, idx))
+
     p_current_steps.append(make_ecc_parm(api, parameters["step_duration"], technique.user_params.duration, idx))
-    p_current_steps.append(make_ecc_parm(api, parameters["vs_init"], technique.user_params.vs_init, idx))
+
     return make_ecc_parms(api, *p_current_steps)
 
 

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -145,8 +145,9 @@ class EXIT_COND(Enum):
     STOP_EXPERIMENT = 2
 
 
-@define
-class CPLIM_params:
+@define(kw_only=True)
+class CPLIM:
+    device: BiologicDevice
     current: float
     duration: float = field(validator=validators.ge(0))
     vs_init: bool
@@ -169,85 +170,70 @@ class CPLIM_params:
     xctr: int | None = None
     # analog_filter  : int
 
+    def _make_cplim_parms(self):
+        # dictionary of CP parameters (non exhaustive)
+        CPLIM_parm_names = {
+            "current_step": ECC_parm("Current_step", float),
+            "step_duration": ECC_parm("Duration_step", float),
+            "vs_init": ECC_parm("vs_initial", bool),
+            "nb_steps": ECC_parm("Step_number", int),
+            "record_dt": ECC_parm("Record_every_dT", float),
+            "record_dE": ECC_parm("Record_every_dE", float),
+            "repeat": ECC_parm("N_Cycles", int),
+            "i_range": ECC_parm("I_Range", int),
+            "e_range": ECC_parm("E_Range", int),
+            "exit_cond": ECC_parm("Exit_Cond", int),
+            "xctr": ECC_parm("xctr", int),
+            "test1_config": ECC_parm("Test1_Config", int),
+            "test1_value": ECC_parm("Test1_Value", float),
+            "bandwidth": ECC_parm("Bandwidth", int),
+            # 'analog_filter': ECC_parm('Filter', int)
+        }
 
-def make_CPLIM_ecc_params(api: BiologicDevice, parameters: CPLIM_params):
-    # dictionary of CP parameters (non exhaustive)
-    CPLIM_parm_names = {
-        "current_step": ECC_parm("Current_step", float),
-        "step_duration": ECC_parm("Duration_step", float),
-        "vs_init": ECC_parm("vs_initial", bool),
-        "nb_steps": ECC_parm("Step_number", int),
-        "record_dt": ECC_parm("Record_every_dT", float),
-        "record_dE": ECC_parm("Record_every_dE", float),
-        "repeat": ECC_parm("N_Cycles", int),
-        "i_range": ECC_parm("I_Range", int),
-        "e_range": ECC_parm("E_Range", int),
-        "exit_cond": ECC_parm("Exit_Cond", int),
-        "xctr": ECC_parm("xctr", int),
-        "test1_config": ECC_parm("Test1_Config", int),
-        "test1_value": ECC_parm("Test1_Value", float),
-        "bandwidth": ECC_parm("Bandwidth", int),
-        # 'analog_filter': ECC_parm('Filter', int)
-    }
+        if self.i_range == KBIO.I_RANGE.I_RANGE_AUTO:
+            raise ValueError("For this technique, I_RANGE_AUTO is not allowed.")
 
-    if parameters.i_range == KBIO.I_RANGE.I_RANGE_AUTO:
-        raise ValueError("For this technique, I_RANGE_AUTO is not allowed.")
+        idx = 0  # Only one current step is used
+        p_current_steps = list()
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["current_step"], self.current, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["step_duration"], self.duration, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["vs_init"], self.vs_init, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["exit_cond"], self.exit_cond.value, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["test1_config"], self.limit_variable, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["test1_value"], self.limit_values, idx))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["nb_steps"], self.nb_steps))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["record_dt"], self.record_dt))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["record_dE"], self.record_dE))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["repeat"], self.repeat))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["i_range"], self.i_range.value))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["e_range"], self.e_range.value))
+        p_current_steps.append(make_ecc_parm(self.device, CPLIM_parm_names["bandwidth"], self.bandwidth.value))
+        # p_filter         = make_ecc_parm( api, CPLIM_parm_names['analog_filter'], 0)#KBIO.FILTER[parameters.analog_filter].value)
+        # make the technique parameter array
 
-    idx = 0  # Only one current step is used
-    p_current_steps = list()
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["current_step"], parameters.current, idx))
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["step_duration"], parameters.duration, idx))
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["vs_init"], parameters.vs_init, idx))
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["exit_cond"], parameters.exit_cond.value, idx))
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["test1_config"], parameters.limit_variable, idx))
-    p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["test1_value"], parameters.limit_values, idx))
-    p_nb_steps = make_ecc_parm(api, CPLIM_parm_names["nb_steps"], parameters.nb_steps)
-    p_record_dt = make_ecc_parm(api, CPLIM_parm_names["record_dt"], parameters.record_dt)
-    p_record_dE = make_ecc_parm(api, CPLIM_parm_names["record_dE"], parameters.record_dE)
-    p_repeat = make_ecc_parm(api, CPLIM_parm_names["repeat"], parameters.repeat)
-    p_IRange = make_ecc_parm(api, CPLIM_parm_names["i_range"], parameters.i_range.value)
-    p_ERange = make_ecc_parm(api, CPLIM_parm_names["e_range"], parameters.e_range.value)
-    p_band = make_ecc_parm(api, CPLIM_parm_names["bandwidth"], parameters.bandwidth.value)
-    # p_filter         = make_ecc_parm( api, CPLIM_parm_names['analog_filter'], 0)#KBIO.FILTER[parameters.analog_filter].value)
-    # make the technique parameter array
-    parms = [
-        *p_current_steps,
-        p_nb_steps,
-        p_record_dt,
-        p_record_dE,
-        p_IRange,
-        p_ERange,
-        p_repeat,
-        p_band,
-        # p_filter,
-    ]
+        if self.xctr:
+            p_xctr = make_ecc_parm(self.device, CPLIM_parm_names["xctr"], self.xctr)
+            p_current_steps.append(p_xctr)
 
-    if parameters.xctr:
-        p_xctr = make_ecc_parm(api, CPLIM_parm_names["xctr"], parameters.xctr)
-        parms.append(p_xctr)
+        ecc_parms_CPLIM = make_ecc_parms(
+            self.device,
+            *p_current_steps,
+        )
+        return ecc_parms_CPLIM
 
-    ecc_parms_CPLIM = make_ecc_parms(
-        api,
-        *parms,
-    )
-    return ecc_parms_CPLIM
+    def make_technique(self):
+        # Name of the dll for the CPLIM technique (for both types of instruments VMP3/VSP300)
+        cplim3_tech_file = "cplimit.ecc"
+        cplim4_tech_file = "cplimit4.ecc"
 
+        # pick the correct ecc file based on the instrument family
+        tech_file_CPLIM = cplim3_tech_file if self.device.is_VMP3 else cplim4_tech_file
 
-def CPLIM_tech(api: BiologicDevice, is_VMP3: bool, parameters: CPLIM_params):
-    # Name of the dll for the CPLIM technique (for both types of instruments VMP3/VSP300)
-    cplim3_tech_file = "cplimit.ecc"
-    cplim4_tech_file = "cplimit4.ecc"
+        # Define parameters for loading in the device using the templates
+        ecc_parms_CPLIM = self._make_cplim_parms()
 
-    # pick the correct ecc file based on the instrument family
-    tech_file_CPLIM = cplim3_tech_file if is_VMP3 else cplim4_tech_file
-
-    # Define parameters for loading in the device using the templates
-    ecc_parms_CPLIM = make_CPLIM_ecc_params(api, parameters)
-
-    CPLIM_tech = namedtuple("CPLIM_tech", "ecc_file ecc_params user_params")
-    cplim_tech = CPLIM_tech(tech_file_CPLIM, ecc_parms_CPLIM, parameters)
-
-    return cplim_tech
+        CPLIM_tech = namedtuple("CPLIM_tech", "ecc_file ecc_params")
+        return CPLIM_tech(tech_file_CPLIM, ecc_parms_CPLIM)
 
 
 # ------CA------- #

--- a/src/pyeclab/techniques.py
+++ b/src/pyeclab/techniques.py
@@ -142,12 +142,12 @@ class CPLIM_params:
     record_dt: float
     record_dE: float
     repeat: int
-    i_range: int
-    e_range: int
+    i_range: KBIO.I_RANGE
+    e_range: KBIO.E_RANGE
     exit_cond: int
     limit_variable: int
     limit_values: float
-    bandwidth: int
+    bandwidth: KBIO.BANDWIDTH
     xctr: int | None = None
     # analog_filter  : int
 
@@ -172,6 +172,9 @@ def make_CPLIM_ecc_params(api: BiologicDevice, parameters: CPLIM_params):
         # 'analog_filter': ECC_parm('Filter', int)
     }
 
+    if parameters.i_range == KBIO.I_RANGE.I_RANGE_AUTO:
+        raise ValueError("For this technique, I_RANGE_AUTO is not allowed.")
+
     idx = 0  # Only one current step is used
     p_current_steps = list()
     p_current_steps.append(make_ecc_parm(api, CPLIM_parm_names["current_step"], parameters.current, idx))
@@ -184,9 +187,9 @@ def make_CPLIM_ecc_params(api: BiologicDevice, parameters: CPLIM_params):
     p_record_dt = make_ecc_parm(api, CPLIM_parm_names["record_dt"], parameters.record_dt)
     p_record_dE = make_ecc_parm(api, CPLIM_parm_names["record_dE"], parameters.record_dE)
     p_repeat = make_ecc_parm(api, CPLIM_parm_names["repeat"], parameters.repeat)
-    p_IRange = make_ecc_parm(api, CPLIM_parm_names["i_range"], parameters.i_range)
-    p_ERange = make_ecc_parm(api, CPLIM_parm_names["e_range"], parameters.e_range)
-    p_band = make_ecc_parm(api, CPLIM_parm_names["bandwidth"], parameters.bandwidth)
+    p_IRange = make_ecc_parm(api, CPLIM_parm_names["i_range"], parameters.i_range.value)
+    p_ERange = make_ecc_parm(api, CPLIM_parm_names["e_range"], parameters.e_range.value)
+    p_band = make_ecc_parm(api, CPLIM_parm_names["bandwidth"], parameters.bandwidth.value)
     # p_filter         = make_ecc_parm( api, CPLIM_parm_names['analog_filter'], 0)#KBIO.FILTER[parameters.analog_filter].value)
     # make the technique parameter array
     parms = [


### PR DESCRIPTION
Thanks for opening that branch!
Here are additional changes I made the last couple of days:

Breaking: When defining a CPLIM technique, the workflow is now slightly different and arguments now need to be defined using keywords. Look at `examples/cppl.py` for an example.

- Make the xctr parameter optional for CPLIM, as it only works with P-series potentiostats
- Refactor the CPLIM class/functions into one class
  -  use attrs package for dataclass like functionality, but with compatibility for keywoard-only attributes with full backwards compatibility
  - use validators to throw an error on wrong value input for CpLim according to potentiostat manual
- Make CPLIM accept Enums instead of ints for I_Range, E_Range, Bandwith and Exit_Cond
- add an example file for cplim
- import main modules into __init__ so they can be imported with `from pyeclab import BiologicDevice` etc.
- fix end_technique when using OCV or when trying to end first method
- add logging to some parts of the program, mostly for debugging.

Todo: 
- fix the examples to use the new cplim-technique
